### PR TITLE
add step to install hex for circle ci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     docker:
       # specify the version here
       - image: circleci/elixir:1.4
-      
+
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images
       # documented at https://circleci.com/docs/2.0/circleci-images/
@@ -18,6 +18,7 @@ jobs:
       - checkout
 
       # specify any bash command here prefixed with `run: `
+      - run: mix local.hex --force
       - run: mix deps.get
       - run: mix ecto.create
       - run: mix test


### PR DESCRIPTION
CIrcle Ci build was failing due to this error.

![image](https://user-images.githubusercontent.com/12948906/38810856-9ee10176-41a5-11e8-8554-ac7260c93733.png)


This PR fixes that.